### PR TITLE
Fix broken empty trash icon on gnome-colors theme

### DIFF
--- a/gnome-colors/gnome-colors-common/scalable/places/user-trash.svg
+++ b/gnome-colors/gnome-colors-common/scalable/places/user-trash.svg
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
+
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="48px"
    height="48px"
    id="svg10460"
    sodipodi:version="0.32"
-   inkscape:version="0.46"
-   sodipodi:docname="drawing-1.svg"
-   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+   inkscape:version="1.1 (1:1.1+202105261517+ce6663b3b7)"
+   sodipodi:docname="user-trash.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.1"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs10462">
     <pattern
@@ -111,7 +113,7 @@
        xlink:href="#linearGradient12878"
        id="linearGradient13683"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(32,0)"
+       gradientTransform="translate(-664,-50.000002)"
        x1="688"
        y1="92.03125"
        x2="688"
@@ -125,7 +127,8 @@
        cy="61.8125"
        fx="705.625"
        fy="61.8125"
-       r="2.5625" />
+       r="2.5625"
+       gradientTransform="matrix(0.8536585,0,0,0.8536585,-586.84947,-11.299441)" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient12852">
@@ -147,7 +150,8 @@
        cy="61.8125"
        fx="705.625"
        fy="61.8125"
-       r="2.5625" />
+       r="2.5625"
+       gradientTransform="matrix(0.8536585,0,0,0.8536585,-587.02625,-37.876606)" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient12746">
@@ -165,7 +169,7 @@
        xlink:href="#linearGradient12746"
        id="radialGradient13562"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4295998,1.1141945,-3.6476752,2.3118514,635.15595,-875.8653)"
+       gradientTransform="matrix(0.5126295,1.0370033,-4.3526694,2.1516868,-71.499432,-861.61044)"
        cx="712.10883"
        cy="64.059387"
        fx="712.10883"
@@ -192,7 +196,7 @@
        y1="62.875"
        x2="736"
        y2="97.625"
-       gradientTransform="translate(2,0)" />
+       gradientTransform="translate(-694,-50.000002)" />
     <linearGradient
        id="linearGradient12900"
        inkscape:collect="always">
@@ -210,7 +214,7 @@
        xlink:href="#linearGradient12900"
        id="linearGradient13697"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(2,1)"
+       gradientTransform="translate(-694,-49.000002)"
        x1="728.40839"
        y1="64.525352"
        x2="728.40839"
@@ -256,7 +260,7 @@
        xlink:href="#linearGradient5577-6-8-4"
        id="linearGradient13695"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(2,1)"
+       gradientTransform="translate(-694,-49.000002)"
        x1="700.99268"
        y1="60.5"
        x2="735.00732"
@@ -282,7 +286,7 @@
        fx="717.30127"
        fy="48.938816"
        r="16.05958"
-       gradientTransform="matrix(1,0,0,0.4551539,0,33.031297)"
+       gradientTransform="matrix(1.1827048,0,0,0.45994485,-821.85575,-15.634162)"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        id="linearGradient3913">
@@ -322,7 +326,7 @@
        xlink:href="#linearGradient11188"
        id="radialGradient13730"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.7793732,-5.980716e-2,-0.4712936,6.1416349,1287.3027,-365.18617)"
+       gradientTransform="matrix(-0.7793732,-0.05980716,-0.4712936,6.1416349,1287.3027,-365.18617)"
        cx="711.0412"
        cy="79.293671"
        fx="711.0412"
@@ -333,7 +337,7 @@
        xlink:href="#linearGradient11188"
        id="radialGradient13728"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7793732,-5.980716e-2,0.4712936,6.1416349,89.22854,-365.18617)"
+       gradientTransform="matrix(0.7793732,-0.05980716,0.4712936,6.1416349,89.22854,-365.18617)"
        cx="709.76562"
        cy="79.28125"
        fx="709.76562"
@@ -356,7 +360,7 @@
        xlink:href="#linearGradient11099"
        id="linearGradient13726"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-30,0)"
+       gradientTransform="translate(-30)"
        x1="717.3125"
        y1="86.961266"
        x2="717.3125"
@@ -406,7 +410,7 @@
        xlink:href="#linearGradient11151"
        id="linearGradient13722"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-30,0)"
+       gradientTransform="translate(-30)"
        x1="701.375"
        y1="73"
        x2="711.375"
@@ -428,7 +432,7 @@
        xlink:href="#linearGradient12961"
        id="radialGradient13540"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.216998,-1.6399267,0.5263804,0.709307,-186.63724,1192.5984)"
+       gradientTransform="matrix(1.2428921,-1.2428921,0.5375802,0.53758016,-897.01286,895.41687)"
        cx="718.77856"
        cy="58.220146"
        fx="718.77856"
@@ -542,7 +546,7 @@
        xlink:href="#linearGradient12890"
        id="radialGradient13530"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.4042553,0,36.117021)"
+       gradientTransform="matrix(1.327663,0,0,0.51387284,-925.52793,9.2989495)"
        cx="715.1875"
        cy="60.625"
        fx="715.1875"
@@ -553,7 +557,7 @@
        xlink:href="#linearGradient11188"
        id="radialGradient13528"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.7793732,-5.980716e-2,-0.4712936,6.1416349,1317.3027,-377.18617)"
+       gradientTransform="matrix(-0.7793732,-0.05980716,-0.4712936,6.1416349,1317.3027,-377.18617)"
        cx="711.0412"
        cy="79.293671"
        fx="711.0412"
@@ -576,7 +580,7 @@
        xlink:href="#linearGradient11188"
        id="radialGradient13526"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7793732,-5.980716e-2,0.4712936,6.1416349,119.22854,-377.18617)"
+       gradientTransform="matrix(0.7793732,-0.05980716,0.4712936,6.1416349,119.22854,-377.18617)"
        cx="709.76562"
        cy="79.28125"
        fx="709.76562"
@@ -672,16 +676,18 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="7"
-     inkscape:cx="24"
-     inkscape:cy="24"
+     inkscape:cx="18"
+     inkscape:cy="15.357143"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
-     inkscape:window-width="641"
-     inkscape:window-height="688"
-     inkscape:window-x="862"
-     inkscape:window-y="146" />
+     inkscape:window-width="1918"
+     inkscape:window-height="1010"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:window-maximized="1" />
   <metadata
      id="metadata10465">
     <rdf:RDF>
@@ -697,217 +703,177 @@
      id="layer1"
      inkscape:label="Layer 1"
      inkscape:groupmode="layer">
+    <path
+       transform="translate(-754,-51.000002)"
+       mask="url(#mask12808)"
+       id="path12941"
+       d="m 778,53.5 c 9.65956,0 17.49998,2.464001 17.5,5.5 v 3.5 l -2.5,24 c 0,3.316468 -6.71998,6.000001 -15,6 -8.28,0 -14.99998,-2.683531 -15,-6 l -2.5,-24 V 59 c 0,-3.035999 7.84041,-5.499998 17.5,-5.5 z"
+       style="display:inline;opacity:0.4;fill:url(#radialGradient13524);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new" />
     <g
-       style="opacity:1;display:inline;filter:url(#filter3625);enable-background:new"
-       id="g3757"
-       transform="translate(-696,-50.000002)">
+       transform="translate(-694,-50.000002)"
+       id="g12830"
+       style="display:inline;enable-background:new">
       <path
-         transform="translate(-58,-1)"
-         mask="url(#mask12808)"
-         id="path12941"
-         d="M 778,53.5 C 787.65956,53.5 795.49998,55.964001 795.5,59 L 795.5,62.5 L 793,86.5 C 793,89.816468 786.28002,92.500001 778,92.5 C 769.72,92.5 763.00002,89.816469 763,86.5 L 760.5,62.5 L 760.5,59 C 760.5,55.964001 768.34041,53.500002 778,53.5 z"
-         style="opacity:0.4;fill:url(#radialGradient13524);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
-      <g
-         transform="translate(2,0)"
-         id="g12830"
-         style="display:inline;enable-background:new">
-        <path
-           id="path12822"
-           d="M 703.65625,57.34375 L 706.62437,80.75 C 706.62437,81.279709 706.82949,81.791672 707.21799,82.28125 C 709.43001,83.089207 712.39892,80.765405 715.875,81.21875 C 715.8408,81.012168 715.8255,80.806814 715.8255,80.59375 L 714.292,56.25 C 710.11541,55.811575 706.46604,58.144644 703.65625,57.34375 L 703.65625,57.34375 z"
-           style="opacity:0.2;fill:url(#radialGradient13526);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
-           sodipodi:nodetypes="ccccccc" />
-        <path
-           id="path12824"
-           d="M 732.875,57.34375 L 729.90688,80.75 C 729.90688,81.279709 729.70176,81.791672 729.31326,82.28125 C 727.10124,83.089207 724.13233,80.765405 720.65625,81.21875 C 720.69045,81.012168 720.70575,80.806814 720.70575,80.59375 L 722.23925,56.25 C 726.41584,55.811575 730.06521,58.144644 732.875,57.34375 z"
-           style="opacity:0.5;fill:url(#radialGradient13528);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
-           sodipodi:nodetypes="ccccccc" />
-      </g>
+         id="path12822"
+         d="M 703.65625,57.34375 706.62437,80.75 c 0,0.529709 0.20512,1.041672 0.59362,1.53125 2.21202,0.807957 5.18093,-1.515845 8.65701,-1.0625 -0.0342,-0.206582 -0.0495,-0.411936 -0.0495,-0.625 L 714.292,56.25 c -4.17659,-0.438425 -7.82596,1.894644 -10.63575,1.09375 z"
+         style="display:inline;opacity:0.2;fill:url(#radialGradient13526);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new"
+         sodipodi:nodetypes="ccccccc" />
       <path
-         transform="matrix(1.327663,0,0,1.2711592,-229.52793,13.388468)"
-         d="M 729.875,60.625 A 14.6875,5.9375 0 1 1 700.5,60.625 A 14.6875,5.9375 0 1 1 729.875,60.625 z"
-         sodipodi:ry="5.9375"
-         sodipodi:rx="14.6875"
-         sodipodi:cy="60.625"
-         sodipodi:cx="715.1875"
-         id="path12888"
-         style="fill:url(#radialGradient13530);fill-opacity:1;stroke:none;display:inline;enable-background:new"
-         sodipodi:type="arc" />
+         id="path12824"
+         d="M 732.875,57.34375 729.90688,80.75 c 0,0.529709 -0.20512,1.041672 -0.59362,1.53125 -2.21202,0.807957 -5.18093,-1.515845 -8.65701,-1.0625 0.0342,-0.206582 0.0495,-0.411936 0.0495,-0.625 L 722.23925,56.25 c 4.17659,-0.438425 7.82596,1.894644 10.63575,1.09375 z"
+         style="display:inline;opacity:0.5;fill:url(#radialGradient13528);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new"
+         sodipodi:nodetypes="ccccccc" />
+    </g>
+    <ellipse
+       id="path12888"
+       style="display:inline;fill:url(#radialGradient13530);fill-opacity:1;stroke:none;stroke-width:1.2991;enable-background:new"
+       cx="24.000051"
+       cy="40.452492"
+       rx="19.50005"
+       ry="7.5475078" />
+    <ellipse
+       id="path12886"
+       style="display:inline;opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1153;enable-background:new"
+       cx="24.000034"
+       cy="40.5"
+       rx="16.688622"
+       ry="6.500001" />
+    <g
+       transform="translate(-694,-70.000002)"
+       id="g12921"
+       style="display:inline;enable-background:new">
       <path
-         transform="matrix(1.1362466,0,0,1.094737,-92.629335,24.13157)"
-         d="M 729.875,60.625 A 14.6875,5.9375 0 1 1 700.5,60.625 A 14.6875,5.9375 0 1 1 729.875,60.625 z"
-         sodipodi:ry="5.9375"
-         sodipodi:rx="14.6875"
-         sodipodi:cy="60.625"
-         sodipodi:cx="715.1875"
-         id="path12886"
-         style="opacity:0.3;fill:#000000;fill-opacity:1;stroke:none;display:inline;enable-background:new"
-         sodipodi:type="arc" />
-      <g
-         transform="translate(2,-20)"
-         id="g12921"
-         style="display:inline;enable-background:new">
-        <path
-           style="fill:url(#linearGradient13534);fill-opacity:1;stroke:url(#linearGradient13536);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;display:inline;enable-background:new"
-           d="M 718,100.875 C 709.16799,100.875 701.47286,103.52466 702,106.6875 L 702.5,109.6875 C 703.02714,112.85034 709.44397,115.5 718,115.5 C 726.55601,115.5 732.97286,112.85034 733.5,109.6875 L 734,106.6875 C 734.52714,103.52466 726.83202,100.875 718,100.875 z"
-           id="path11082"
-           sodipodi:nodetypes="csssssc" />
-        <path
-           style="fill:url(#linearGradient13538);fill-opacity:1;stroke:none;display:inline;enable-background:new"
-           d="M 718,101.25 C 713.79541,101.25 709.86942,101.89964 707.07937,102.9375 C 705.68434,103.45643 704.57033,104.07409 703.86918,104.71875 C 703.16803,105.36341 702.89662,105.98437 702.99913,106.625 L 703.14914,107.625 C 703.29458,107.32766 703.53929,107.02207 703.86918,106.71875 C 704.57033,106.07409 705.68434,105.45643 707.07937,104.9375 C 709.86942,103.89964 713.79541,103.25 718,103.25 C 722.2046,103.25 726.13058,103.89964 728.92063,104.9375 C 730.31566,105.45643 731.42967,106.07409 732.13082,106.71875 C 732.46071,107.02207 732.70542,107.32766 732.85086,107.625 L 733.00087,106.625 C 733.10338,105.98437 732.83197,105.36341 732.13082,104.71875 C 731.42967,104.07409 730.31566,103.45643 728.92063,102.9375 C 726.13058,101.89964 722.2046,101.25 718,101.25 z"
-           id="path12912" />
-      </g>
+         style="display:inline;fill:url(#linearGradient13534);fill-opacity:1;stroke:url(#linearGradient13536);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+         d="m 718,100.875 c -8.83201,0 -16.52714,2.64966 -16,5.8125 l 0.5,3 c 0.52714,3.16284 6.94397,5.8125 15.5,5.8125 8.55601,0 14.97286,-2.64966 15.5,-5.8125 l 0.5,-3 c 0.52714,-3.16284 -7.16798,-5.8125 -16,-5.8125 z"
+         id="path11082"
+         sodipodi:nodetypes="csssssc" />
       <path
-         transform="matrix(1.021277,0,0,0.7578949,-10.40454,41.552624)"
-         d="M 729.875,60.625 A 14.6875,5.9375 0 1 1 700.5,60.625 A 14.6875,5.9375 0 1 1 729.875,60.625 z"
-         sodipodi:ry="5.9375"
-         sodipodi:rx="14.6875"
-         sodipodi:cy="60.625"
-         sodipodi:cx="715.1875"
-         id="path11259"
-         style="fill:url(#radialGradient13540);fill-opacity:1;stroke:none;display:inline;enable-background:new"
-         sodipodi:type="arc" />
-      <g
-         transform="translate(32,0)"
-         id="g11279"
-         style="display:inline;enable-background:new">
-        <path
-           style="fill:url(#linearGradient13722);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
-           d="M 688,53.5 C 678.34044,53.5 670.50002,55.964001 670.5,59 L 670.5,62.5 L 673,86.5 C 673,89.816468 679.71998,92.500001 688,92.5 L 688,53.5 z"
-           id="path11121" />
-        <path
-           style="fill:url(#linearGradient13724);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
-           d="M 688,53.5 L 688,92.5 C 696.28002,92.500001 703,89.816468 703,86.5 L 705.5,62.5 L 705.5,59 C 705.49998,55.964001 697.65956,53.5 688,53.5 z"
-           id="path11141" />
-        <path
-           style="fill:none;stroke:url(#linearGradient13726);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-           d="M 688,53.5 C 678.34044,53.5 670.50002,55.964001 670.5,59 L 670.5,62.5 L 673,86.5 C 673,89.816468 679.71998,92.500001 688,92.5 C 696.28,92.5 702.99998,89.816469 703,86.5 L 705.5,62.5 L 705.5,59 C 705.5,55.964001 697.65959,53.500002 688,53.5 z"
-           id="path11089" />
-        <path
-           style="fill:url(#radialGradient13728);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
-           d="M 673.65625,66.34375 L 676.62437,88.75 C 676.62437,89.279709 676.82949,89.791672 677.21799,90.28125 C 679.43001,91.089207 682.39892,91.765405 685.875,92.21875 C 685.8408,92.012168 685.8255,91.806814 685.8255,91.59375 L 684.292,68.25 C 680.11541,67.811575 676.46604,67.144644 673.65625,66.34375 L 673.65625,66.34375 z"
-           id="path11178" />
-        <path
-           style="opacity:0.4;fill:url(#radialGradient13730);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
-           d="M 702.875,66.34375 L 699.90688,88.75 C 699.90688,89.279709 699.70176,89.791672 699.31326,90.28125 C 697.10124,91.089207 694.13233,91.765405 690.65625,92.21875 C 690.69045,92.012168 690.70575,91.806814 690.70575,91.59375 L 692.23925,68.25 C 696.41584,67.811575 700.06521,67.144644 702.875,66.34375 z"
-           id="path11196" />
-      </g>
+         style="display:inline;fill:url(#linearGradient13538);fill-opacity:1;stroke:none;enable-background:new"
+         d="m 718,101.25 c -4.20459,0 -8.13058,0.64964 -10.92063,1.6875 -1.39503,0.51893 -2.50904,1.13659 -3.21019,1.78125 -0.70115,0.64466 -0.97256,1.26562 -0.87005,1.90625 l 0.15001,1 c 0.14544,-0.29734 0.39015,-0.60293 0.72004,-0.90625 0.70115,-0.64466 1.81516,-1.26232 3.21019,-1.78125 2.79005,-1.03786 6.71604,-1.6875 10.92063,-1.6875 4.2046,0 8.13058,0.64964 10.92063,1.6875 1.39503,0.51893 2.50904,1.13659 3.21019,1.78125 0.32989,0.30332 0.5746,0.60891 0.72004,0.90625 l 0.15001,-1 c 0.10251,-0.64063 -0.1689,-1.26159 -0.87005,-1.90625 -0.70115,-0.64466 -1.81516,-1.26232 -3.21019,-1.78125 C 726.13058,101.89964 722.2046,101.25 718,101.25 Z"
+         id="path12912" />
+    </g>
+    <ellipse
+       id="path11259"
+       style="display:inline;fill:url(#radialGradient13540);fill-opacity:1;stroke:none;stroke-width:0.879784;enable-background:new"
+       cx="24.000004"
+       cy="37.5"
+       rx="15.000006"
+       ry="4.500001" />
+    <g
+       transform="translate(-664,-50.000002)"
+       id="g11279"
+       style="display:inline;enable-background:new">
       <path
-         style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.89999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;display:inline;enable-background:new"
-         d="M 720,55.5 C 712.24288,55.5 705.62248,57.182054 702.875,59.5625 L 702.875,62.25 L 703.53125,62.25 C 703.51465,62.16703 703.46875,62.084082 703.46875,62 C 703.46875,59.501564 710.8776,57.46875 720,57.46875 C 729.12242,57.468748 736.53125,59.501564 736.53125,62 C 736.53125,62.08408 736.48535,62.167032 736.46875,62.25 L 737.25,62.25 L 737.25,59.6875 C 734.59075,57.243169 727.88795,55.500001 720,55.5 z"
-         id="path13063" />
+         style="display:inline;fill:url(#linearGradient13722);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new"
+         d="m 688,53.5 c -9.65956,0 -17.49998,2.464001 -17.5,5.5 v 3.5 l 2.5,24 c 0,3.316468 6.71998,6.000001 15,6 z"
+         id="path11121" />
       <path
-         style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.89999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;display:inline;enable-background:new"
-         d="M 703.6875,65.15625 L 703.90625,67.1875 C 707.08756,69.155103 713.10325,70.499998 720,70.5 C 726.89674,70.5 732.91244,69.155103 736.09375,67.1875 L 736.3125,65.15625 L 703.6875,65.15625 z"
-         id="path13051"
-         sodipodi:nodetypes="ccsccc" />
+         style="display:inline;fill:url(#linearGradient13724);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new"
+         d="m 688,53.5 v 39 c 8.28002,10e-7 15,-2.683532 15,-6 l 2.5,-24 V 59 c -2e-5,-3.035999 -7.84044,-5.5 -17.5,-5.5 z"
+         id="path11141" />
       <path
-         transform="translate(-58,0)"
-         mask="url(#mask12808)"
-         id="path12758"
-         d="M 778,53.5 C 787.65956,53.5 795.49998,55.964001 795.5,59 L 795.5,62.5 C 784.28933,65.463984 772.65327,65.662942 760.5,62.5 L 760.5,59 C 760.5,55.964001 768.34041,53.500002 778,53.5 z"
-         style="opacity:1;fill:url(#linearGradient3911);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
-         sodipodi:nodetypes="cccccc" />
+         style="fill:none;stroke:url(#linearGradient13726);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 688,53.5 c -9.65956,0 -17.49998,2.464001 -17.5,5.5 v 3.5 l 2.5,24 c 0,3.316468 6.71998,6.000001 15,6 8.28,0 14.99998,-2.683531 15,-6 l 2.5,-24 V 59 c 0,-3.035999 -7.84041,-5.499998 -17.5,-5.5 z"
+         id="path11089" />
       <path
-         transform="matrix(1.1827048,0,0,1.010526,-125.85575,0.9868556)"
-         d="M 729.875,60.625 A 14.6875,5.9375 0 1 1 700.5,60.625 A 14.6875,5.9375 0 1 1 729.875,60.625 z"
-         sodipodi:ry="5.9375"
-         sodipodi:rx="14.6875"
-         sodipodi:cy="60.625"
-         sodipodi:cx="715.1875"
-         id="path12770"
-         style="fill:none;stroke:url(#radialGradient3909);stroke-width:2.74415922;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;display:inline;enable-background:new"
-         sodipodi:type="arc" />
+         style="display:inline;fill:url(#radialGradient13728);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new"
+         d="M 673.65625,66.34375 676.62437,88.75 c 0,0.529709 0.20512,1.041672 0.59362,1.53125 2.21202,0.807957 5.18093,1.484155 8.65701,1.9375 -0.0342,-0.206582 -0.0495,-0.411936 -0.0495,-0.625 L 684.292,68.25 c -4.17659,-0.438425 -7.82596,-1.105356 -10.63575,-1.90625 z"
+         id="path11178" />
       <path
-         id="path11065"
-         d="M 720,53.5 C 709.78801,53.5 701.50001,56.412001 701.5,60 L 701.5,63 C 701.5,66.588 709.788,69.499997 720,69.5 C 730.21199,69.5 738.49997,66.588001 738.5,63 L 738.5,60 C 738.5,56.412 730.21198,53.500001 720,53.5 z M 720,55.46875 C 729.12242,55.468748 736.53125,57.501564 736.53125,60 C 736.53123,62.498436 729.1224,64.53125 720,64.53125 C 710.87763,64.531252 703.46875,62.498436 703.46875,60 C 703.46875,57.501564 710.8776,55.46875 720,55.46875 z"
-         style="fill:url(#linearGradient13695);fill-opacity:1;stroke:url(#linearGradient13697);stroke-width:0.89999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;display:inline;enable-background:new" />
+         style="display:inline;opacity:0.4;fill:url(#radialGradient13730);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new"
+         d="M 702.875,66.34375 699.90688,88.75 c 0,0.529709 -0.20512,1.041672 -0.59362,1.53125 -2.21202,0.807957 -5.18093,1.484155 -8.65701,1.9375 0.0342,-0.206582 0.0495,-0.411936 0.0495,-0.625 L 692.23925,68.25 c 4.17659,-0.438425 7.82596,-1.105356 10.63575,-1.90625 z"
+         id="path11196" />
+    </g>
+    <path
+       style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       d="m 24,5.499998 c -7.75712,0 -14.37752,1.682054 -17.125,4.0625 v 2.6875 h 0.65625 c -0.0166,-0.08297 -0.0625,-0.165918 -0.0625,-0.25 0,-2.498436 7.40885,-4.53125 16.53125,-4.53125 9.12242,-2e-6 16.53125,2.032814 16.53125,4.53125 0,0.08408 -0.0459,0.167032 -0.0625,0.25 H 41.25 v -2.5625 C 38.59075,7.243167 31.88795,5.499999 24,5.499998 Z"
+       id="path13063" />
+    <path
+       style="display:inline;opacity:0.1;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       d="m 7.6875,15.156248 0.21875,2.03125 c 3.18131,1.967603 9.197,3.312498 16.09375,3.3125 6.89674,0 12.91244,-1.344897 16.09375,-3.3125 l 0.21875,-2.03125 z"
+       id="path13051"
+       sodipodi:nodetypes="ccsccc" />
+    <path
+       transform="translate(-754,-50.000002)"
+       mask="url(#mask12808)"
+       id="path12758"
+       d="m 778,53.5 c 9.65956,0 17.49998,2.464001 17.5,5.5 v 3.5 c -11.21067,2.963984 -22.84673,3.162942 -35,0 V 59 c 0,-3.035999 7.84041,-5.499998 17.5,-5.5 z"
+       style="display:inline;fill:url(#linearGradient3911);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new"
+       sodipodi:nodetypes="cccccc" />
+    <ellipse
+       id="path12770"
+       style="display:inline;fill:none;stroke:url(#radialGradient3909);stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       cx="23.999939"
+       cy="12.249992"
+       rx="17.370977"
+       ry="5.9999981" />
+    <path
+       id="path11065"
+       d="m 24,3.499998 c -10.21199,0 -18.49999,2.912001 -18.5,6.5 v 3 c 0,3.588 8.288,6.499997 18.5,6.5 10.21199,0 18.49997,-2.911999 18.5,-6.5 v -3 c 0,-3.588 -8.28802,-6.499999 -18.5,-6.5 z m 0,1.96875 c 9.12242,-2e-6 16.53125,2.032814 16.53125,4.53125 -2e-5,2.498436 -7.40885,4.53125 -16.53125,4.53125 -9.12237,2e-6 -16.53125,-2.032814 -16.53125,-4.53125 0,-2.498436 7.40885,-4.53125 16.53125,-4.53125 z"
+       style="display:inline;fill:url(#linearGradient13695);fill-opacity:1;stroke:url(#linearGradient13697);stroke-width:0.9;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+    <path
+       sodipodi:nodetypes="cssccsccsccsssccsccsccssc"
+       id="path11239"
+       d="m 24,4.499998 c -5.01158,0 -9.55046,0.719588 -12.75,1.84375 C 9.65023,6.905829 8.39356,7.585975 7.59375,8.249998 6.79394,8.914021 6.5,9.485387 6.5,9.999998 v 3 c 0,0.421835 0.24593,0.935042 0.875,1.53125 0.17642,0.163611 0.28747,0.385695 0.3125,0.625 l 2.125,19.4375 c 0.0248,0.288989 -0.0779,0.574384 -0.28125,0.78125 -0.48455,0.495408 -0.61461,0.843559 -0.5625,1.15625 l 0.5,3 c 0.16352,0.981126 1.53901,2.314042 4.125,3.3125 2.58599,0.998458 6.23077,1.65625 10.40625,1.65625 4.17547,0 7.82026,-0.657792 10.40625,-1.65625 2.58599,-0.998458 3.96148,-2.331377 4.125,-3.3125 l 0.5,-3 c 0.0521,-0.312691 -0.0779,-0.660842 -0.5625,-1.15625 -0.20331,-0.206866 -0.30606,-0.492261 -0.28125,-0.78125 l 2.125,-19.4375 c 0.025,-0.239305 0.13608,-0.461389 0.3125,-0.625 0.62907,-0.596205 0.87499,-1.109399 0.875,-1.53125 v -3 c 0,-0.51461 -0.29394,-1.085977 -1.09375,-1.75 C 39.60644,7.585975 38.34977,6.905829 36.75,6.343748 33.55046,5.219587 29.01158,4.499998 24,4.499998 Z"
+       style="display:inline;opacity:0.4;fill:none;stroke:url(#linearGradient13692);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;enable-background:new" />
+    <ellipse
+       id="path11078"
+       style="display:inline;fill:none;stroke:url(#radialGradient13562);stroke-width:0.947698;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       cx="23.999992"
+       cy="10"
+       rx="17.526186"
+       ry="5.5261512" />
+    <circle
+       id="path12850"
+       style="display:inline;fill:url(#radialGradient13564);fill-opacity:1;stroke:none;stroke-width:0.853658;enable-background:new"
+       cx="15.336529"
+       cy="14.89016"
+       r="2.1875" />
+    <circle
+       id="path12860"
+       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.410449;enable-background:new"
+       cx="15.336518"
+       cy="14.89016"
+       r="1.0517765" />
+    <circle
+       id="path12862"
+       style="display:inline;fill:url(#radialGradient13566);fill-opacity:1;stroke:none;stroke-width:0.853658;enable-background:new"
+       cx="15.513309"
+       cy="41.467323"
+       r="2.1875" />
+    <circle
+       id="path12864"
+       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.410449;enable-background:new"
+       cx="15.513298"
+       cy="41.467323"
+       r="1.0517765" />
+    <circle
+       id="path12868"
+       style="display:inline;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.312888;enable-background:new"
+       cx="33.312477"
+       cy="5.4374962"
+       r="0.80177653" />
+    <path
+       id="path12874"
+       d="m 7.8125,20.624998 1.65625,15.8125 c 10e-4,0.02081 10e-4,0.04169 0,0.0625 0,0.667196 0.33526,1.341968 1.03125,2 0.69599,0.658032 1.74404,1.285386 3.0625,1.8125 2.63692,1.054227 6.34929,1.71875 10.4375,1.71875 4.0882,0 7.80058,-0.664523 10.4375,-1.71875 1.31846,-0.527113 2.36651,-1.154468 3.0625,-1.8125 0.69599,-0.658032 1.03125,-1.332804 1.03125,-2 -10e-4,-0.02081 -10e-4,-0.04169 0,-0.0625 l 1.65625,-15.8125 z"
+       style="display:inline;opacity:0.7;fill:url(#linearGradient13683);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new" />
+    <g
+       transform="translate(-755.99372,-49.911614)"
+       id="g13005"
+       style="display:inline;opacity:0.199029;enable-background:new">
       <path
-         sodipodi:nodetypes="cssccsccsccsssccsccsccssc"
-         id="path11239"
-         d="M 720,54.5 C 714.98842,54.5 710.44954,55.219588 707.25,56.34375 C 705.65023,56.905831 704.39356,57.585977 703.59375,58.25 C 702.79394,58.914023 702.5,59.485389 702.5,60 L 702.5,63 C 702.5,63.421835 702.74593,63.935042 703.375,64.53125 C 703.55142,64.694861 703.66247,64.916945 703.6875,65.15625 L 705.8125,84.59375 C 705.8373,84.882739 705.7346,85.168134 705.53125,85.375 C 705.0467,85.870408 704.91664,86.218559 704.96875,86.53125 L 705.46875,89.53125 C 705.63227,90.512376 707.00776,91.845292 709.59375,92.84375 C 712.17974,93.842208 715.82452,94.5 720,94.5 C 724.17547,94.5 727.82026,93.842208 730.40625,92.84375 C 732.99224,91.845292 734.36773,90.512373 734.53125,89.53125 L 735.03125,86.53125 C 735.08335,86.218559 734.95335,85.870408 734.46875,85.375 C 734.26544,85.168134 734.16269,84.882739 734.1875,84.59375 L 736.3125,65.15625 C 736.3375,64.916945 736.44858,64.694861 736.625,64.53125 C 737.25407,63.935045 737.49999,63.421851 737.5,63 L 737.5,60 C 737.5,59.48539 737.20606,58.914023 736.40625,58.25 C 735.60644,57.585977 734.34977,56.905831 732.75,56.34375 C 729.55046,55.219589 725.01158,54.5 720,54.5 z"
-         style="opacity:0.4;fill:none;stroke:url(#linearGradient13692);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;display:inline;enable-background:new" />
+         style="display:inline;fill:url(#radialGradient13542-7);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new"
+         mask="url(#mask12799-3)"
+         d="M 762.5,59.1875 V 61.5 l 2.5,24 c 0,3.316468 6.71998,6.000001 15,6 8.28,0 14.99998,-2.683531 15,-6 l 2.5,-24 v -2.3125 c -0.31778,2.962627 -8.0271,5.34375 -17.5,5.34375 -9.47291,0 -17.18222,-2.381121 -17.5,-5.34375 z"
+         id="path12929" />
       <path
-         transform="matrix(1.1932722,0,0,0.9307202,-133.41337,3.57509)"
-         d="M 729.875,60.625 A 14.6875,5.9375 0 1 1 700.5,60.625 A 14.6875,5.9375 0 1 1 729.875,60.625 z"
-         sodipodi:ry="5.9375"
-         sodipodi:rx="14.6875"
-         sodipodi:cy="60.625"
-         sodipodi:cx="715.1875"
-         id="path11078"
-         style="fill:none;stroke:url(#radialGradient13562);stroke-width:0.89927071;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;display:inline;enable-background:new"
-         sodipodi:type="arc" />
-      <path
-         transform="matrix(0.8536585,0,0,0.8536585,108.97375,12.123396)"
-         d="M 708.1875,61.8125 A 2.5625,2.5625 0 1 1 703.0625,61.8125 A 2.5625,2.5625 0 1 1 708.1875,61.8125 z"
-         sodipodi:ry="2.5625"
-         sodipodi:rx="2.5625"
-         sodipodi:cy="61.8125"
-         sodipodi:cx="705.625"
-         id="path12850"
-         style="fill:url(#radialGradient13564);fill-opacity:1;stroke:none;display:inline;enable-background:new"
-         sodipodi:type="arc" />
-      <path
-         transform="matrix(0.4104494,0,0,0.4104494,421.71316,39.519258)"
-         d="M 708.1875,61.8125 A 2.5625,2.5625 0 1 1 703.0625,61.8125 A 2.5625,2.5625 0 1 1 708.1875,61.8125 z"
-         sodipodi:ry="2.5625"
-         sodipodi:rx="2.5625"
-         sodipodi:cy="61.8125"
-         sodipodi:cx="705.625"
-         id="path12860"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline;enable-background:new"
-         sodipodi:type="arc" />
-      <path
-         transform="matrix(0.8536585,0,0,0.8536585,109.15053,38.700561)"
-         d="M 708.1875,61.8125 A 2.5625,2.5625 0 1 1 703.0625,61.8125 A 2.5625,2.5625 0 1 1 708.1875,61.8125 z"
-         sodipodi:ry="2.5625"
-         sodipodi:rx="2.5625"
-         sodipodi:cy="61.8125"
-         sodipodi:cx="705.625"
-         id="path12862"
-         style="fill:url(#radialGradient13566);fill-opacity:1;stroke:none;display:inline;enable-background:new"
-         sodipodi:type="arc" />
-      <path
-         transform="matrix(0.4104494,0,0,0.4104494,421.88994,66.096423)"
-         d="M 708.1875,61.8125 A 2.5625,2.5625 0 1 1 703.0625,61.8125 A 2.5625,2.5625 0 1 1 708.1875,61.8125 z"
-         sodipodi:ry="2.5625"
-         sodipodi:rx="2.5625"
-         sodipodi:cy="61.8125"
-         sodipodi:cx="705.625"
-         id="path12864"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline;enable-background:new"
-         sodipodi:type="arc" />
-      <path
-         transform="matrix(0.3128884,0,0,0.3128884,508.5306,36.097084)"
-         d="M 708.1875,61.8125 A 2.5625,2.5625 0 1 1 703.0625,61.8125 A 2.5625,2.5625 0 1 1 708.1875,61.8125 z"
-         sodipodi:ry="2.5625"
-         sodipodi:rx="2.5625"
-         sodipodi:cy="61.8125"
-         sodipodi:cx="705.625"
-         id="path12868"
-         style="fill:#ffffff;fill-opacity:1;stroke:none;display:inline;enable-background:new"
-         sodipodi:type="arc" />
-      <path
-         id="path12874"
-         d="M 703.8125,70.625 L 705.46875,86.4375 C 705.46975,86.45831 705.46975,86.47919 705.46875,86.5 C 705.46875,87.167196 705.80401,87.841968 706.5,88.5 C 707.19599,89.158032 708.24404,89.785386 709.5625,90.3125 C 712.19942,91.366727 715.91179,92.03125 720,92.03125 C 724.0882,92.03125 727.80058,91.366727 730.4375,90.3125 C 731.75596,89.785387 732.80401,89.158032 733.5,88.5 C 734.19599,87.841968 734.53125,87.167196 734.53125,86.5 C 734.53025,86.47919 734.53025,86.45831 734.53125,86.4375 L 736.1875,70.625 L 703.8125,70.625 z"
-         style="opacity:0.7;fill:url(#linearGradient13683);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
-      <g
-         transform="translate(-59.993716,8.8388e-2)"
-         id="g13005"
-         style="opacity:0.19902912;display:inline;enable-background:new">
-        <path
-           style="fill:url(#radialGradient13542-7);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
-           mask="url(#mask12799-3)"
-           d="M 762.5,59.1875 L 762.5,61.5 L 765,85.5 C 765,88.816468 771.71998,91.500001 780,91.5 C 788.28,91.5 794.99998,88.816469 795,85.5 L 797.5,61.5 L 797.5,59.1875 C 797.18222,62.150127 789.4729,64.53125 780,64.53125 C 770.52709,64.53125 762.81778,62.150129 762.5,59.1875 z"
-           id="path12929" />
-        <path
-           sodipodi:nodetypes="ccsccc"
-           clip-path="none"
-           style="fill:url(#pattern12787-0);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;enable-background:new"
-           d="M 751.25,65.8125 L 753.5,86.5 C 753.5,89.816468 759.71998,92.000001 768,92 C 776.28,92 782.62498,89.816469 782.625,86.5 L 784.625,65.8125 C 776.68757,70.672961 759.64924,70.800766 751.25,65.8125 z"
-           id="path11171"
-           mask="none"
-           transform="translate(12,0)" />
-      </g>
+         sodipodi:nodetypes="ccsccc"
+         clip-path="none"
+         style="display:inline;fill:url(#pattern12787-0);fill-opacity:1;fill-rule:evenodd;stroke:none;enable-background:new"
+         d="M 751.25,65.8125 753.5,86.5 c 0,3.316468 6.21998,5.500001 14.5,5.5 8.28,0 14.62498,-2.183531 14.625,-5.5 l 2,-20.6875 c -7.93743,4.860461 -24.97576,4.988266 -33.375,0 z"
+         id="path11171"
+         mask="none"
+         transform="translate(12)" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
On recent versions of ubuntu based systems (20.04) seems to be issues with the scalable empty trash icon format.
This impacts users using this icon set on their DE theme.

Hopefully this can be of help.
Cheers.